### PR TITLE
Add an option to require GPUs

### DIFF
--- a/src/bicleaner_ai/bicleaner_ai_classifier.py
+++ b/src/bicleaner_ai/bicleaner_ai_classifier.py
@@ -90,7 +90,7 @@ def initialization(argv = None):
                     f"Model {args.model} not found at HF Hub. If the model is private use --auth_token option.")
         raise FileNotFoundError(f"model {args.metadata} no such file")
 
-    check_gpu()
+    check_gpu(args.require_gpus)
 
     # Load metadata YAML
     args = load_metadata(args, parser)

--- a/src/bicleaner_ai/classify.py
+++ b/src/bicleaner_ai/classify.py
@@ -61,6 +61,7 @@ def argument_parser():
     groupO.add_argument('--disable_minimal_length', default=False, action='store_true', help="Don't apply minimal length rule")
     groupO.add_argument('--run_all_rules', default=False, action='store_true', help="Run all rules of Hardrules instead of stopping at first discard")
     groupO.add_argument('--rules_config', type=argparse.FileType('r'), default=None, help="Hardrules configuration file")
+    groupO.add_argument('--require_gpu', default=False, action='store_true', help="Quit if the GPUs are not available")
 
     # HuggingFace Hub options
     groupO.add_argument('--offline', default=False, action='store_true', help="Don't try to download the model, instead try directly to load from local storage")

--- a/src/bicleaner_ai/util.py
+++ b/src/bicleaner_ai/util.py
@@ -115,11 +115,19 @@ def logging_setup(args = None):
         tf.get_logger().setLevel('ERROR')
 
 
-def check_gpu():
+def check_gpu(require_gpus: bool):
     import tensorflow as tf
     devices = tf.config.list_physical_devices('GPU') + tf.config.list_physical_devices('TPU')
     if not devices:
-        logging.warning("No GPU or TPU was detected. Running on CPU will be slow.")
+        if require_gpus:
+            # Exit with a 75 EX_TEMPFAIL, which indicates a temporary error. GPUs can
+            # become unavailable in the cloud, and 75 indicates that the task can be
+            # retried.
+            logging.error("No GPU or TPU detected and --require_gpu was specified. Exiting with a EX_TEMPFAIL (75)")
+            sys.exit(75)
+        else:
+            logging.warning("No GPU or TPU was detected. Running on CPU will be slow.")
+
 
 def shuffle_file(input: typing.TextIO, output: typing.TextIO):
     offsets=[]


### PR DESCRIPTION
We're having cloud tasks that drop their GPUs, and then we run on CPU mode, which is slow and very expensive. This option makes GPUs required, and exits with the an [EX_TEMPFAIL (75)](https://man.openbsd.org/sysexits#EX_TEMPFAIL), which can be used as a signal that the task can be restarted.